### PR TITLE
[FE | Alert] 현재 시점 이동평균선 추가 및 알림페이지 추가버튼 연결

### DIFF
--- a/app/(tabs)/(alert-manage)/alert-manage.tsx
+++ b/app/(tabs)/(alert-manage)/alert-manage.tsx
@@ -165,7 +165,7 @@ export default function AlertManage() {
 
       <TouchableOpacity
         style={styles.fab}
-        onPress={() => router.push("/(tabs)/(alert-manage)/alert-condition")}
+        onPress={() => router.push("/alert-additional")}
       >
         <Image
           source={require("@/assets/images/alert/company_alert.png")}

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -127,14 +127,15 @@ export default function TabLayout() {
         name="alert-additional/index"
         options={{
           title: "알림 설정",
-          tabBarLabel: ({ focused }) => (
-            <Typography weight={focused ? "600" : "400"} size={12}>
-              추가
-            </Typography>
-          ),
-          tabBarIcon: ({ color }) => (
-            <IconSymbol size={28} name="plus.circle.fill" color={color} />
-          ),
+          href: null,
+          // tabBarLabel: ({ focused }) => (
+          //   <Typography weight={focused ? "600" : "400"} size={12}>
+          //     추가
+          //   </Typography>
+          // ),
+          // tabBarIcon: ({ color }) => (
+          //   <IconSymbol size={28} name="plus.circle.fill" color={color} />
+          // ),
         }}
       />
       <Tabs.Screen

--- a/app/(tabs)/alert-additional/[companyId].tsx
+++ b/app/(tabs)/alert-additional/[companyId].tsx
@@ -67,7 +67,15 @@ export default function CompanyAlertDetail() {
         bollingerUpper={50000}
         bollingerLower={50000}
         rsi={50}
-        movingAverage={50}
+        sma={{
+          "5일": 50000,
+          "10일": 50100,
+          "20일": 50200,
+          "30일": 50300,
+          "50일": 50400,
+          "100일": 50500,
+          "200일": 50600,
+        }}
       />
       <View style={styles.divider} />
       <TextInput

--- a/components/add-card/current-status.tsx
+++ b/components/add-card/current-status.tsx
@@ -12,7 +12,7 @@ interface CurrentStatusCardProps {
   bollingerUpper: number;
   bollingerLower: number;
   rsi: number;
-  movingAverage: number;
+  sma: { [key: string]: number };
 }
 
 export default function CurrentStatusCard({
@@ -25,7 +25,7 @@ export default function CurrentStatusCard({
   bollingerUpper,
   bollingerLower,
   rsi,
-  movingAverage,
+  sma,
 }: CurrentStatusCardProps) {
   const [expanded, setExpanded] = useState(false);
 
@@ -104,11 +104,16 @@ export default function CurrentStatusCard({
             <Text style={styles.mainLabel}>RSI (14일 기준)</Text>
             <Text style={styles.value}>{rsi}</Text>
           </View>
-
           <View style={styles.row}>
             <Text style={styles.mainLabel}>이동평균선</Text>
-            {/* <Text style={styles.value}>{movingAverage}</Text> */}
-            {/* 이동평균선 값은 어떻게 표현할지 안나와있음 */}
+          </View>
+          <View style={styles.maGrid}>
+            {Object.entries(sma).map(([period, value]) => (
+              <View key={period} style={styles.maItem}>
+                <Text style={styles.subLabel}>{period}</Text>
+                <Text style={styles.value}>{value.toLocaleString()}원</Text>
+              </View>
+            ))}
           </View>
         </View>
       )}
@@ -184,5 +189,17 @@ const styles = StyleSheet.create({
   value: {
     fontSize: 15,
     color: "#000",
+  },
+  maGrid: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    justifyContent: "space-between",
+    marginTop: 4,
+  },
+  maItem: {
+    width: "47%",
+    flexDirection: "row",
+    justifyContent: "space-between",
+    marginBottom: 4,
   },
 });

--- a/components/home/active-condition.tsx
+++ b/components/home/active-condition.tsx
@@ -6,7 +6,7 @@ type Condition = {
   name: string;
   count: number;
 };
-
+// 추후 실제 데이터로 교체 필요
 const sampleConditions: Condition[] = [
   { id: 1, name: "알림1", count: 3 },
   { id: 2, name: "알림2", count: 4 },

--- a/components/home/price-toast-alert.tsx
+++ b/components/home/price-toast-alert.tsx
@@ -7,6 +7,7 @@ import Hynix from "../../assets/images/companies/logo_2_하이닉스.svg";
 import Naver from "../../assets/images/companies/logo_7_네이버.svg";
 import Mypage from "../../assets/images/mypage.svg";
 
+// 추후 실제 데이터로 교체 필요
 const alerts = [
   {
     id: 1,
@@ -38,13 +39,12 @@ export default function PriceAlertToast() {
   const router = useRouter();
   const [index, setIndex] = useState(0);
 
-  // ✅ opacity + translateY 조합
+  // 위로 올라가며 fade-out
   const fadeAnim = useRef(new Animated.Value(1)).current;
   const translateY = useRef(new Animated.Value(0)).current;
 
   useEffect(() => {
     const interval = setInterval(() => {
-      // 위로 사라지며 fade-out
       Animated.parallel([
         Animated.timing(fadeAnim, {
           toValue: 0,
@@ -57,10 +57,8 @@ export default function PriceAlertToast() {
           useNativeDriver: true,
         }),
       ]).start(() => {
-        // 다음 메시지로 전환
         setIndex((prev) => (prev + 1) % alerts.length);
 
-        // 위치 초기화 + fade-in
         translateY.setValue(10);
         Animated.parallel([
           Animated.timing(fadeAnim, {
@@ -85,7 +83,6 @@ export default function PriceAlertToast() {
 
   return (
     <View style={styles.container}>
-      {/* ✅ 애니메이션은 토스트 내용에만 적용 */}
       <Animated.View
         style={[
           styles.left,
@@ -99,7 +96,6 @@ export default function PriceAlertToast() {
         <Text style={styles.text}>{current.message}</Text>
       </Animated.View>
 
-      {/* ✅ 마이페이지 버튼은 고정 */}
       <Pressable
         onPress={() => router.push("/mypage")}
         style={styles.mypageBtn}


### PR DESCRIPTION
## 🔀 PR 개요
- 현재 시점 이동평균선 추가 및 알림페이지 추가버튼 연결

---

## ✅ 작업 내용
- 알림 조건 추가 페이지에 현재 시점에 이동평균선 값 추가
- 탭에서 추가 탭 빼고, 알림에서 기업 알림 추가버튼과 연결

---

## 📌 관련 이슈
- #22 

---

## 📸 스크린샷 (선택)
<img width="1170" height="2532" alt="image" src="https://github.com/user-attachments/assets/2058d4d5-c6d0-4ad5-a4f3-7c2a6b35b469" />

---

## ⚠️ 기타 사항
- 기업 알림 탭으로 이름 변경 필요